### PR TITLE
Add README, tests and local env script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# IoT Application Deployment
+
+This repository contains the automation and Kubernetes manifests for the IoT Application. The original project began as a monolithic Spring Boot backend and has been refactored into a set of microservices. All services run in containers and are orchestrated on a Raspberry Pi via K3s.
+
+## Microservices Overview
+
+| Service | Language | Responsibilities |
+|---------|----------|-----------------|
+| Auth Service | Java / Spring Boot | Authentication, JWT generation and validation |
+| User Management Service | Java / Spring Boot | Manage users, roles and permissions |
+| Device Management Service | Python / FastAPI | Register and monitor IoT devices, handle MQTT messages |
+| Data Processing Service | Python / FastAPI | Process incoming device data and expose APIs |
+| Frontend | JavaScript | Web interface for users |
+
+Infrastructure components include PostgreSQL, InfluxDB, Mosquitto and Traefik. The configuration for these components lives in the `k8s/` directory.
+
+## Repository Structure
+
+- `ansible/` – Playbooks to bootstrap Raspberry Pi nodes and install K3s and Helm charts.
+- `k8s/` – Kubernetes manifests for all services and infrastructure.
+- `archive/` – Deprecated or legacy manifests kept for reference.
+- `scripts/` – Helper scripts, including a local testing environment.
+- `tests/` – Pytest suite validating the manifests.
+
+## Getting Started
+
+### Prerequisites
+- Docker
+- [kind](https://kind.sigs.k8s.io/) for running a local Kubernetes cluster
+- Python 3.11 with `pytest` and `pyyaml`
+
+### Local Test Environment
+
+To spin up a local cluster and apply all manifests, run:
+
+```bash
+scripts/setup_local_env.sh
+```
+
+The script expects `kind` and `kubectl` to be available. It will create a cluster named `iotapp`, create the `iot` namespace, and apply all manifests from the `k8s/` directory.
+
+### Deploying to Raspberry Pi
+
+1. Configure your hosts in `ansible/inventory/inventory.yml`.
+2. Execute the base deployment which installs Traefik, cert‑manager and monitoring tools:
+   ```bash
+   ansible-playbook -i ansible/inventory/inventory.yml ansible/deploy_basis.yml
+   ```
+3. Deploy the application services:
+   ```bash
+   ansible-playbook -i ansible/inventory/inventory.yml ansible/deploy_services.yml
+   ```
+
+Credentials for pulling container images are expected as extra variables or environment variables as shown in the GitHub Actions workflow.
+
+### Running Tests
+
+Install test requirements and run `pytest`:
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
+The test suite ensures that all YAML manifests load correctly and that the cluster issuer referenced in the ingress matches the issuer manifest.
+
+## Known Issues
+
+- The ingress annotation for the frontend previously referenced `letsencrypt-production`. It has been corrected to `letsencrypt-prod` to match the cluster issuer in `k8s/98-deployment-prod/cluster-issuer.yaml`.
+- Ensure Traefik is deployed (via Helm in `ansible/deploy_basis.yml`) before applying the dashboard ingress in `k8s/00-traefik`.
+

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: iot
   annotations:
     kubernetes.io/ingress.class: "traefik"
-    cert-manager.io/cluster-issuer: "letsencrypt-production"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   tls:
     - hosts:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pyyaml

--- a/scripts/setup_local_env.sh
+++ b/scripts/setup_local_env.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-iotapp}
+
+if ! command -v kind >/dev/null 2>&1; then
+  echo "kind is required. Install from https://kind.sigs.k8s.io/" >&2
+  exit 1
+fi
+
+# Create cluster if it does not exist
+if ! kind get clusters | grep -q "^${CLUSTER_NAME}$"; then
+  kind create cluster --name "${CLUSTER_NAME}"
+fi
+
+kubectl create namespace iot --dry-run=client -o yaml | kubectl apply -f -
+
+# Apply manifests
+kubectl apply -f k8s/secrets.yaml
+for dir in 1-postgres 2-influx 3-mosquitto 4-user-management 5-auth 6-device-management 7-data-processing 8-frontend 00-traefik 98-deployment-prod; do
+  kubectl apply -f "k8s/${dir}"
+done
+kubectl apply -f k8s/ingress.yaml

--- a/tests/test_yaml_files.py
+++ b/tests/test_yaml_files.py
@@ -1,0 +1,22 @@
+import glob
+import yaml
+from pathlib import Path
+
+
+def load_yaml(path):
+    with open(path) as f:
+        return list(yaml.safe_load_all(f))
+
+def test_k8s_yaml_loads():
+    for path in glob.glob('k8s/**/*.yaml', recursive=True):
+        assert load_yaml(path) is not None, f"Failed to parse {path}"
+
+def test_inventory_yaml():
+    data = load_yaml('ansible/inventory/inventory.yml')[0]
+    assert 'k3s_cluster' in data
+
+def test_ingress_cluster_issuer_match():
+    issuer = load_yaml('k8s/98-deployment-prod/cluster-issuer.yaml')[0]['metadata']['name']
+    ingress = load_yaml('k8s/ingress.yaml')[0]
+    annotation = ingress['metadata']['annotations']['cert-manager.io/cluster-issuer']
+    assert annotation == issuer, f"Ingress annotation {annotation} does not match cluster issuer {issuer}"


### PR DESCRIPTION
## Summary
- document microservice deployment and usage in a new README
- fix frontend ingress cluster issuer name
- add pytest-based sanity tests
- provide script to spin up a local kind cluster
- include requirements-dev.txt for test dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f52f2cf708323b6ce7936337c0bfe